### PR TITLE
restructure SQLAlchemy models

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4,7 +4,7 @@ from os import getenv
 
 from flask import Flask, render_template, request
 
-from .models.hosts import Host, Listing
+from .models import Host, Listing
 
 
 def create_app():

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy models for AIrBnB hosts"""
+"""SQLAlchemy models for AIrBnB listings"""
 
 from flask_sqlalchemy import SQLAlchemy
 

--- a/webapp/models/features.py
+++ b/webapp/models/features.py
@@ -1,8 +1,0 @@
-"""SQLAlchemy models for model categorical features"""
-
-from flask_sqlalchemy import SQLAlchemy
-
-DB = SQLAlchemy()
-
-
-# TODO - Create Tables for categorical features


### PR DESCRIPTION
- Deletes models/ folder and contents
- Moves code from models/hosts.py to models.py

We can build any SQLAlchemy models from models.py since we plan to use only the Host and Listing table anyway. 
The features dictionary can be our data structure for defining input forms. The data that's returned needs to be stored somehow (currently it's a dictionary with a single item).